### PR TITLE
Make install and uninstall robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=3.0~dev3
+VERSION=3.0~dev5
 
 # Do not change this
 SERIES=`lsb_release -c | cut -d: -f2 | sed -e s/"\s"//g`

--- a/debian_privacyidea/changelog
+++ b/debian_privacyidea/changelog
@@ -1,8 +1,8 @@
-privacyidea (3.0~dev3-1trusty) trusty; urgency=medium
+privacyidea (3.0~dev5-1trusty) trusty; urgency=medium
 
   * Push token in master branch 
  
- -- NetKnights GmbH <release@netknights.it>  Fri, 22 Mar 2019 14:00:00 +0200
+ -- NetKnights GmbH <release@netknights.it>  Thu, 28 Mar 2019 15:00:00 +0200
 
 python-privacyidea (2.23.5-1trusty) trusty; urgency=medium
 

--- a/debian_server/changelog
+++ b/debian_server/changelog
@@ -1,6 +1,6 @@
-privacyidea-server (3.0~dev3-1trusty) trusty; urgency=medium
+privacyidea-server (3.0~dev5-1trusty) trusty; urgency=medium
 
   * Push token in master branch 
  
- -- NetKnights GmbH <release@netknights.it>  Fri, 22 Mar 2019 14:00:00 +0200
+ -- NetKnights GmbH <release@netknights.it>  Thu, 28 Mar 2019 15:00:00 +0200
 

--- a/debian_server/privacyidea-apache2.postinst
+++ b/debian_server/privacyidea-apache2.postinst
@@ -29,9 +29,9 @@ create_files() {
         mkdir -p /var/log/privacyidea
         mkdir -p /var/lib/privacyidea
         touch /var/log/privacyidea/privacyidea.log
-        pi-manage create_enckey || true > /dev/null
-        pi-manage createdb || true > /dev/null
-        pi-manage create_audit_keys || true > /dev/null
+        /opt/privacyidea/bin/pi-manage create_enckey || true > /dev/null
+        /opt/privacyidea/bin/pi-manage createdb || true > /dev/null
+        /opt/privacyidea/bin/pi-manage create_audit_keys || true > /dev/null
         chown -R $USERNAME /var/log/privacyidea
         chown -R $USERNAME /var/lib/privacyidea
         chown -R $USERNAME /etc/privacyidea
@@ -111,7 +111,7 @@ enable_apache() {
 
 update_db() {
 	# Upgrade the database
-	privacyidea-schema-upgrade /opt/privacyidea/lib/privacyidea/migrations > /dev/null
+	/opt/privacyidea/bin/privacyidea-schema-upgrade /opt/privacyidea/lib/privacyidea/migrations > /dev/null
 }
 
 create_gpg() {
@@ -124,10 +124,8 @@ create_gpg() {
 
 
 set_path() {
-  if [ -z "$(grep '/opt/privacyidea/bin' /etc/environment)" ]; then
-	  # Write the path to the environment, if it is not there
-	echo 'PATH=$PATH:/opt/privacyidea/bin' >> /etc/environment
-  fi
+	# Allow pi-manage to be called from everywhere
+	ln -s /opt/privacyidea/bin/pi-manage /usr/local/bin
 }
 
 case "$1" in

--- a/debian_server/privacyidea-apache2.postrm
+++ b/debian_server/privacyidea-apache2.postrm
@@ -19,6 +19,10 @@ unset_sites () {
 
 unset_sites $1
 
+# Remove the symbolic link to pi-manage
+if [ -L /usr/local/bin/pi-manage ]; then
+    rm /usr/local/bin/pi-manage
+fi
 
 #DEBHELPER#
 exit 0

--- a/debian_server/privacyidea-nginx.postinst
+++ b/debian_server/privacyidea-nginx.postinst
@@ -29,9 +29,9 @@ create_files() {
         mkdir -p /var/log/privacyidea
         mkdir -p /var/lib/privacyidea
         touch /var/log/privacyidea/privacyidea.log
-	pi-manage create_enckey || true
-	pi-manage createdb || true
-	pi-manage create_audit_keys || true
+	/opt/privacyidea/bin/pi-manage create_enckey || true
+	/opt/privacyidea/bin/pi-manage createdb || true
+	/opt/privacyidea/bin/pi-manage create_audit_keys || true
         chown -R $USERNAME /var/log/privacyidea
         chown -R $USERNAME /var/lib/privacyidea
         chown -R $USERNAME /etc/privacyidea
@@ -106,13 +106,19 @@ enable_nginx_uwsgi() {
 
 update_db() {
         # Upgrade the database
-	privacyidea-schema-upgrade /usr/lib/privacyidea/migrations > /dev/null
+	/opt/privacyidea/bin/privacyidea-schema-upgrade /usr/lib/privacyidea/migrations > /dev/null
 }
 
+
+set_path() {
+	# Allow pi-manage to be called
+	ln -s /opt/privacyidea/bin/pi-manage /usr/local/bin/
+}
 
 case "$1" in
 
   configure)
+        set_path
 	create_user
 	adapt_pi_cfg
 	create_database

--- a/debian_server/privacyidea-nginx.postrm
+++ b/debian_server/privacyidea-nginx.postrm
@@ -19,6 +19,10 @@ unset_sites () {
 
 unset_sites
 
+# Remove the symbolic link to pi-manage
+if [ -L /usr/local/bin/pi-manage ]; then
+    rm /usr/local/bin/pi-manage
+fi
 
 #DEBHELPER#
 exit 0

--- a/deploy/crontab/privacyidea
+++ b/deploy/crontab/privacyidea
@@ -1,2 +1,2 @@
 # Run the privacyidea-cron runner every 5 minutes
-*/5 * * * *	privacyidea	privacyidea-cron run_scheduled -c
+*/5 * * * *	privacyidea	/opt/privacyidea/bin/privacyidea-cron run_scheduled -c


### PR DESCRIPTION
Use links instead of PATH variable.
We create a link for pi-manage.
Other scripts should be called using the full path.