### PR TITLE
Distinguish install and update: Stamp DB

### DIFF
--- a/debian_server/privacyidea-apache2.postinst
+++ b/debian_server/privacyidea-apache2.postinst
@@ -137,6 +137,16 @@ case "$1" in
 	create_user
 	adapt_pi_cfg
 	create_database
+	if [ -z "$2" ]; then
+		# We are in the install step
+		# So we stamp the DB
+    touch /tmp/pi-install
+		/opt/privacyidea/bin/pi-manage db stamp -d /opt/privacyidea/lib/privacyidea/migrations/ head
+	else
+		# We are in an update step
+    touch /tmp/pi-upgrade
+		update_db
+	fi
 	enable_apache
 	create_files
 	create_certificate

--- a/debian_server/privacyidea-nginx.postinst
+++ b/debian_server/privacyidea-nginx.postinst
@@ -115,7 +115,14 @@ case "$1" in
   configure)
 	create_user
 	adapt_pi_cfg
-	create_database
+        if [ -z "$2" ]; then
+		# We are in the install step
+		# So we stamp the DB
+		/opt/privacyidea/bin/pi-manage db stamp -d /opt/privacyidea/lib/privacyidea/migrations/ head
+	else
+		# We are in an update step
+		update_db
+	fi
 	enable_nginx_uwsgi
 	create_files
 	create_certificate
@@ -123,7 +130,6 @@ case "$1" in
 	#update-rc.d uwsgi defaults
 	service uwsgi restart
 	service nginx restart
-	update_db
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
If we run a fresh installation, we have no second
call parameter. We stamp the DB version to "head".

If we run an upgrade, we upgrade the DB schema.

Closes #4