### PR TITLE
Appliance: Do not install /etc/sudoers.d/privacyidea

### DIFF
--- a/debian_appliance/pi-appliance.install
+++ b/debian_appliance/pi-appliance.install
@@ -1,1 +1,0 @@
-authappliance/sudoers/privacyidea	/etc/sudoers.d/


### PR DESCRIPTION
As this was the only entry in ``pi-appliance.install``, we just remove the file.