### PR TITLE
Update forgotten privacyidea Python3 deps

### DIFF
--- a/debian_appliance/control
+++ b/debian_appliance/control
@@ -2,7 +2,7 @@ Source: pi-appliance
 Maintainer: Cornelius Kölbel <cornelius.koelbel@netknights.it>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.7), debhelper (>= 7.4.3), python-setuptools, dh-virtualenv (>= 0.11)
+Build-Depends: python-setuptools (>= 0.6b3), python3-all (>= 3.5), debhelper (>= 7.4.3), python-setuptools, dh-virtualenv (>= 0.11)
 Standards-Version: 3.9.5
 
 

--- a/debian_appliance/rules
+++ b/debian_appliance/rules
@@ -3,4 +3,7 @@
 %:
 	dh $@ --with python-virtualenv
 
+override_dh_virtualenv:
+	dh_virtualenv --python python3
+
 

--- a/debian_privacyidea/changelog
+++ b/debian_privacyidea/changelog
@@ -1,8 +1,8 @@
-privacyidea (3.2~dev1-1trusty) trusty; urgency=medium
+privacyidea (3.2~dev2-1trusty) trusty; urgency=medium
 
   * Changes to be filled
 
- -- NetKnights GmbH <release@netknights.it>  Fri, 15 Nov 2019 12:00:00 +0200
+ -- NetKnights GmbH <release@netknights.it>  Tue, 19 Nov 2019 12:00:00 +0200
 
 privacyidea (3.1.2-1trusty) trusty; urgency=medium
 

--- a/debian_privacyidea/control
+++ b/debian_privacyidea/control
@@ -2,7 +2,7 @@ Source: privacyidea
 Maintainer: Cornelius Kölbel <cornelius.koelbel@netknights.it>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3), python-all (>= 2.7), debhelper (>= 7.4.3), dh-virtualenv (>= 0.11), default-libmysqlclient-dev | libmysqlclient-dev, quilt, libpq-dev
+Build-Depends: python-setuptools (>= 0.6b3), python3-all (>= 3.5), debhelper (>= 7.4.3), dh-virtualenv (>= 0.11), default-libmysqlclient-dev | libmysqlclient-dev, quilt, libpq-dev
 Standards-Version: 3.9.5
 
 Package: privacyidea
@@ -10,9 +10,9 @@ Architecture: amd64
 Replaces: python-privacyidea (<< 3.0)
 Breaks: python-privacyidea (<< 3.0)
 Conflicts: privacyidea-venv, pi-appliance (<= 2.1)
-Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal, ${misc:Pre-Depends}
+Pre-Depends: dpkg (>= 1.16.1), python3-minimal, ${misc:Pre-Depends}
 Depends: ${python:Depends}, ${misc:Depends}, libmysqlclient20 | libmysqlclient18
-X-Python-Version: >= 2.7
+X-Python-Version: >= 3.5
 Description: two-factor authentication system e.g. for OTP devices
  privacyIDEA: identity, multifactor authentication, authorization.
  This package contains the python module for privacyIDEA. If you want

--- a/debian_server/changelog
+++ b/debian_server/changelog
@@ -1,9 +1,9 @@
-privacyidea-server (3.2~dev1-2trusty) trusty; urgency=medium
+privacyidea-server (3.2~dev2-1trusty) trusty; urgency=medium
 
   * Add Barracuda MySQL fix to NGinX installation
   * Do not restart MySQL database, if Barracuda fix is already in place
 
- -- NetKnights GmbH <release@netknights.it>  Mon, 28 Oct 2019 11:30:00 +0200
+ -- NetKnights GmbH <release@netknights.it>  Tue, 19 Nov 2019 11:30:00 +0200
 
 privacyidea-server (3.1.2-1trusty) trusty; urgency=medium
 


### PR DESCRIPTION
Although due to the rules files the virtualenv was
built with Python 3 the dependencies in the control
file were missing.