### PR TITLE
Add failsafe for empty enabled-sites directories

### DIFF
--- a/debian_radius/bionic/privacyidea-radius.postinst
+++ b/debian_radius/bionic/privacyidea-radius.postinst
@@ -16,7 +16,7 @@ activate_perl() {
 }
 
 activate_site() {
-	rm -f /etc/freeradius/3.0/sites-enabled/*
+	rm -f /etc/freeradius/3.0/sites-enabled/* || true
 	ln -s /etc/freeradius/3.0/sites-available/privacyidea /etc/freeradius/3.0/sites-enabled/
 }
 

--- a/debian_radius/xenial/privacyidea-radius.postinst
+++ b/debian_radius/xenial/privacyidea-radius.postinst
@@ -12,7 +12,7 @@ if [ -f /usr/share/dbconfig-common/dpkg/postinst.pgsql  ]; then
 fi
 
 activate_site() {
-	rm /etc/freeradius/sites-enabled/*
+	rm /etc/freeradius/sites-enabled/* || true
 	ln -s /etc/freeradius/sites-available/privacyidea /etc/freeradius/sites-enabled/
 }
 


### PR DESCRIPTION
Add a || true after the rm, so that the postinst script
will not fail, even if the directory is empty.

Closes #30