### PR TITLE
Fix build for ubuntu 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Do not change this
-SERIES=`lsb_release -c | cut -d: -f2 | sed -e s/"\s"//g`
+SERIES=$(shell lsb_release -cs)
 BUILDDIR_PI=DEBUILD/privacyidea.orig
 BUILDDIR_SERVER=DEBUILD/privacyidea-server.orig
 BUILDDIR_RADIUS=DEBUILD/privacyidea-radius.orig

--- a/debian_privacyidea/control
+++ b/debian_privacyidea/control
@@ -2,7 +2,7 @@ Source: privacyidea
 Maintainer: Cornelius Kölbel <cornelius.koelbel@netknights.it>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3), python3-all (>= 3.5), debhelper (>= 7.4.3), dh-virtualenv (>= 0.11), default-libmysqlclient-dev | libmysqlclient-dev, quilt, libpq-dev, python3-dev, python3-virtualenv 
+Build-Depends: python-setuptools (>= 0.6b3), python3-all (>= 3.5), debhelper (>= 7.4.3), dh-virtualenv (>= 0.11), quilt, python3-dev, python3-virtualenv
 Standards-Version: 3.9.5
 
 Package: privacyidea
@@ -19,9 +19,8 @@ Description: two-factor authentication system e.g. for OTP devices
  to run it in a productive webserver you might want to install
  privacyidea-nginx or privacyidea-apache2.
  privacyIDEA is an open solution for strong two-factor authentication.
- privacyIDEA aims to not bind you to any decision of the authentication protocol 
- or it does not dictate you where your user information should be stored. 
+ privacyIDEA aims to not bind you to any decision of the authentication protocol
+ or it does not dictate you where your user information should be stored.
  This is achieved by its totally modular architecture.
- privacyIDEA is not only open as far as its modular architecture is concerned. 
+ privacyIDEA is not only open as far as its modular architecture is concerned.
  But privacyIDEA is completely licensed under the AGPLv3.
-

--- a/debian_privacyidea/rules
+++ b/debian_privacyidea/rules
@@ -11,12 +11,14 @@
 #	dh_virtualenv --upgrade-pip
 #
 override_dh_virtualenv:
+ifeq ($(shell lsb_release -rs), 16.04)
+	dh_virtualenv --python python3 --preinstall=setuptools==50.3.2
+else
 	dh_virtualenv --python python3
+endif
 
 override_dh_shlibdeps:
 	dh_shlibdeps --exclude=psycopg2 --exclude=libz --exclude=png16  --exclude=Pillow.libs
 
 override_dh_strip:
 	dh_strip --exclude=cffi --exclude=PIL --exclude=Pillow --exclude=psycopg2
-
-


### PR DESCRIPTION
Current Ubuntu 16.04 comes with a broken python setuptools package.
To avoid running into this, the setuptools is pinned and installed in
the virtualenv before the requirements are processed.

Also the build does not depend on mysql/postgres libraries anymore.