### PR TITLE
Fix uwsgi buffer size for chrome

### DIFF
--- a/deploy/uwsgi/apps-available/privacyidea.xml
+++ b/deploy/uwsgi/apps-available/privacyidea.xml
@@ -11,6 +11,7 @@
     <cpu-affinity>1</cpu-affinity>
     <stats>/tmp/stats.socket</stats>
     <max-requests>2000</max-requests>
+    <buffer-size>8192</buffer-size>
     <limit-as>1024</limit-as>
     <reload-on-as>368</reload-on-as>
     <reload-on-rss>192</reload-on-rss>


### PR DESCRIPTION
When requesting the audit-log with the Chrome browser we got an "Nginx
Bad Gateway" error. Further examining the issue there was an entry in
the uwsgi log corresponding to the audit log request:
``invalid request block size: 4142 (max 4096)...skip``
It turns out that with the Auth-token the headers sent from the browser
were just below the 4k limit of the uwsgi buffer-size:
https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size
Chrome added some extra headers which exceeded the 4k.
Why this happened only while getting the audit-log is not clear to me
(maybe because of the long query string).
Also with PI 3.5 this did not happen.
Anyway, increasing the buffer-size to 8k should fix this.