### PR TITLE
Update WSGI settings for single application

### DIFF
--- a/deploy/apache/sites-available/privacyidea.conf
+++ b/deploy/apache/sites-available/privacyidea.conf
@@ -29,6 +29,7 @@
 	# This user should have access to the encKey database encryption file
 	WSGIDaemonProcess privacyidea processes=1 threads=15 display-name=%{GROUP} user=privacyidea
 	WSGIProcessGroup privacyidea
+	WSGIApplicationGroup %{GLOBAL}
 	WSGIPassAuthorization On
 
 	ErrorLog /var/log/apache2/error.log


### PR DESCRIPTION
Adding the `WSGIApplicationGroup %{GLOBAL}` settings prevents the app from freezing due to compiled extensions in some modules.

Closes #61