### PR TITLE
Add daily cron entry for remember-device session cleanup

### DIFF
--- a/deploy/crontab/privacyidea
+++ b/deploy/crontab/privacyidea
@@ -7,6 +7,9 @@
 # Challenge cleanup: every day at 01:00
 0 1 * * *    privacyidea     /opt/privacyidea/bin/pi-manage config challenge cleanup > /dev/null 2>&1
 
+# Remember-device session cleanup: every day at 01:10
+10 1 * * *    privacyidea     /opt/privacyidea/bin/pi-manage config authsession cleanup > /dev/null 2>&1
+
 # Run a backup once a day at 2:15 am including the encryption key
 #15 2 * * *	privacyidea	/opt/privacyidea/bin/pi-manage backup create -e
 


### PR DESCRIPTION
Adds a daily `pi-manage config authsession cleanup` entry to `deploy/crontab/privacyidea` so expired persistent "remember this device" sessions (the `auth_sessions` table) are reclaimed, mirroring the existing challenge-cleanup entry.

**Dependency:** requires the privacyIDEA server to provide the `config authsession cleanup` command, which is introduced by the API-clients / remember-device feature (privacyidea PR #5694). Do **not** release this ahead of that command existing, or the cron job will error.

Runs at 01:10 daily (just after the 01:00 challenge cleanup).